### PR TITLE
added decompress and compress transforms and the related tests.

### DIFF
--- a/kseg/data/transforms.py
+++ b/kseg/data/transforms.py
@@ -231,7 +231,6 @@ class Vec2Complex(NDTransform, torchio.SpatialTransform):
 
         cols_rest = torch.complex(real=data[:, 0, :, :, 1:], imag=data[:, 1, :, :, 1:])
 
-        print(data.shape, cols_rest.shape, cols_decompressed.shape)
         data = rearrange(
             pack(
                 [

--- a/kseg/main.py
+++ b/kseg/main.py
@@ -44,15 +44,9 @@ def main():
 @click.option('--num-cpus', '--cpus', default=32)
 @click.option('--num_gpus', '--gpus', default=1)
 @click.option('--skip-checkpoints', '--sc', is_flag=True, default=False)
-@click.option(
-    '--output_dir', '--out', default='.', type=click.Path(exists=True)
-)
-@click.option(
-    '--datasets-path', default='./datasets', type=click.Path(exists=True)
-)
-@click.option(
-    '--config-path', default='./config.yml', type=click.Path(exists=True)
-)
+@click.option('--output_dir', '--out', default='.', type=click.Path(exists=True))
+@click.option('--datasets-path', default='./datasets', type=click.Path(exists=True))
+@click.option('--config-path', default='./config.yml', type=click.Path(exists=True))
 @click.option('--resume', is_flag=True, default=False)
 @click.option('--tuning', is_flag=True, default=False)
 def train(
@@ -154,9 +148,7 @@ def train(
     # We're using grid search only, we sample each value once
     num_samples = 1
 
-    scheduler = ASHAScheduler(
-        max_t=epochs, grace_period=100, reduction_factor=2
-    )
+    scheduler = ASHAScheduler(max_t=epochs, grace_period=100, reduction_factor=2)
 
     # Display either hparams or standard parameter in CLIReporter
     if tuning:
@@ -165,9 +157,7 @@ def train(
             if isinstance(value, list):
                 config[key] = tune.grid_search(value)
         parameter_columns = [
-            k
-            for k, v in config.items()
-            if isinstance(v, dict) and 'grid_search' in v
+            k for k, v in config.items() if isinstance(v, dict) and 'grid_search' in v
         ]
     else:
         parameter_columns = ['lr', 'criterion']
@@ -191,9 +181,7 @@ def train(
     resources_per_trial = {'cpu': num_cpus, 'gpu': num_gpus}
 
     tuner = tune.Tuner(
-        tune.with_resources(
-            train_fn_with_parameters, resources=resources_per_trial
-        ),
+        tune.with_resources(train_fn_with_parameters, resources=resources_per_trial),
         tune_config=tune.TuneConfig(
             metric='val_avg_dice',
             mode='max',
@@ -217,9 +205,7 @@ def train(
 @click.argument('checkpoint_path', type=click.Path(exists=True))
 @click.option('--batch-size', default=4)
 @click.option('--num_gpus', '--gpus', default=1)
-@click.option(
-    '--config-path', default='./config.yml', type=click.Path(exists=True)
-)
+@click.option('--config-path', default='./config.yml', type=click.Path(exists=True))
 def test(
     data_name: str,
     checkpoint_path: str,
@@ -248,7 +234,7 @@ def test(
         idx = checkpoint_path_parts.index('pytorch_logs')
         train_worker_path = '/'.join(checkpoint_path_parts[: idx + 2]) + '/'
     except ValueError:
-        raise ValueError(f'Given checkpoint path is invalid.')
+        raise ValueError('Given checkpoint path is invalid.')
 
     # Load model and weights from checkpoint and set model to eval mode
     model = LitModel.load_from_checkpoint(checkpoint_path)

--- a/kseg/model/loss.py
+++ b/kseg/model/loss.py
@@ -52,21 +52,15 @@ class HighFreqMSELoss(nn.Module):
         if self.fourier_plane_enc == 'sagittal':
             enc_shape = diff.shape[-3:-1]
             freq_weights = self.get_freq_weights(enc_shape, diff.device.type)
-            freq_weights = freq_weights[
-                np.newaxis, np.newaxis, :, :, np.newaxis
-            ]
+            freq_weights = freq_weights[np.newaxis, np.newaxis, :, :, np.newaxis]
         elif self.fourier_plane_enc == 'coronal':
             enc_shape = (diff.shape[1], diff.shape[3])
             freq_weights = self.get_freq_weights(enc_shape, diff.device.type)
-            freq_weights = freq_weights[
-                np.newaxis, :, np.newaxis, :, np.newaxis
-            ]
+            freq_weights = freq_weights[np.newaxis, :, np.newaxis, :, np.newaxis]
         elif self.fourier_plane_enc == 'axial':
             enc_shape = diff.shape[1:3]
             freq_weights = self.get_freq_weights(enc_shape, diff.device.type)
-            freq_weights = freq_weights[
-                np.newaxis, :, :, np.newaxis, np.newaxis
-            ]
+            freq_weights = freq_weights[np.newaxis, :, :, np.newaxis, np.newaxis]
         else:
             raise ValueError('Unknown Fourier plane encoding')
 
@@ -173,9 +167,7 @@ class DiceLoss(nn.Module):
         union = reduce(inputs + targets, 'b c v x y z -> c', 'sum')
 
         # Calculate Dice score for each class
-        dice_scores = (2.0 * intersection + self.smooth) / (
-            union + self.smooth
-        )
+        dice_scores = (2.0 * intersection + self.smooth) / (union + self.smooth)
         return 1 - dice_scores.mean()
 
 
@@ -210,9 +202,7 @@ class WeightedMSELoss(nn.Module):
 
         loss = 0
         for i, w in enumerate(self.weight):
-            mse_class = F.mse_loss(
-                y_hat[:, i, ...], y[:, i, ...], reduction='none'
-            )
+            mse_class = F.mse_loss(y_hat[:, i, ...], y[:, i, ...], reduction='none')
             weighted_mse_class = w * mse_class
             loss += weighted_mse_class.sum()
 

--- a/kseg/model/modules.py
+++ b/kseg/model/modules.py
@@ -37,9 +37,7 @@ class PreNorm(nn.Module):
 class MLP_Block(nn.Module):
     """Building block for MLP-based models."""
 
-    def __init__(
-        self, hidden_size: int, activation: nn.Module, depth: int
-    ) -> None:
+    def __init__(self, hidden_size: int, activation: nn.Module, depth: int) -> None:
         """Initialization of the MLP block.
 
         Args:
@@ -216,9 +214,7 @@ class ResMLP_Block(nn.Module):
         self.layerscale_1 = nn.Parameter(
             layerscale_init * torch.ones((latent_dim))
         )  # LayerScale parameters
-        self.layerscale_2 = nn.Parameter(
-            layerscale_init * torch.ones((latent_dim))
-        )
+        self.layerscale_2 = nn.Parameter(layerscale_init * torch.ones((latent_dim)))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Propagates the input through the ResMLP block.
@@ -324,9 +320,7 @@ class DomainInputAdapter(InputAdapter):
     x-slice dimension acts as input channels.
     """
 
-    def __init__(
-        self, input_shape: Tuple[int], num_frequency_bands: int
-    ) -> None:
+    def __init__(self, input_shape: Tuple[int], num_frequency_bands: int) -> None:
         """Initialization of the domain input adapter for the PerceiverIO.
 
         Args:
@@ -377,7 +371,7 @@ class DomainInputAdapter(InputAdapter):
 
         # b (batch), c (class), v (real/imag-part), x, y, z
         x = rearrange(x, 'b c v x y z -> b (c v z y) x')
-        if self.position_encoding == None:
+        if self.position_encoding is None:
             return x
 
         x_enc = self.position_encoding(b)
@@ -387,9 +381,7 @@ class DomainInputAdapter(InputAdapter):
 class SegmentationOutputAdapter(OutputAdapter):
     """Transforms generic decoder cross-attention output to segmentation map."""
 
-    def __init__(
-        self, output_len: int, num_output_query_channels: int
-    ) -> None:
+    def __init__(self, output_len: int, num_output_query_channels: int) -> None:
         """Initialization of the segmentation output adapter.
 
         Args:
@@ -462,9 +454,7 @@ class PerceiverIO(nn.Module):
             num_query_channels=output_query_channels,
             init_scale=0.02,  # scale for Gaussian query initialization
         )
-        output_adapter = SegmentationOutputAdapter(
-            output_len, output_query_channels
-        )
+        output_adapter = SegmentationOutputAdapter(output_len, output_query_channels)
         modules = (
             PerceiverEncoder(
                 input_adapter=input_adapter,
@@ -541,9 +531,7 @@ class Transformer(nn.Module):
         input_len = int(np.prod([*input_shape[:2], *input_shape[3:]]))
         output_len = int(np.prod([*output_shape[:2], *output_shape[3:]]))
         hidden_size = int(input_len * hidden_factor)
-        self.input_adapter = DomainInputAdapter(
-            input_shape, num_frequency_bands
-        )
+        self.input_adapter = DomainInputAdapter(input_shape, num_frequency_bands)
 
         in_linear = nn.Linear(input_len, hidden_size)
         encoder_layers = nn.TransformerEncoderLayer(
@@ -552,9 +540,7 @@ class Transformer(nn.Module):
         transformer_encoder = nn.TransformerEncoder(encoder_layers, depth)
         out_linear = nn.Linear(hidden_size, output_len)
 
-        self.layers = nn.ModuleList(
-            [in_linear, transformer_encoder, out_linear]
-        )
+        self.layers = nn.ModuleList([in_linear, transformer_encoder, out_linear])
         self.layers = nn.Sequential(*self.layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -611,9 +597,7 @@ class DiceScore(nn.Module):
         union = torch.sum(y_pred + y_true, dim=(0, 2, 3, 4, 5))
 
         # Calculate Dice score for each class
-        dice_scores = (2.0 * intersection + self.smooth) / (
-            union + self.smooth
-        )
+        dice_scores = (2.0 * intersection + self.smooth) / (union + self.smooth)
 
         # Return average Dice score and per class Dice score
         return dice_scores.mean(), dice_scores

--- a/kseg/utils/config_handler.py
+++ b/kseg/utils/config_handler.py
@@ -5,10 +5,8 @@ import torch_optimizer
 import yaml
 
 from importlib import metadata
-from ray import tune
 from typing import Dict, Any, Optional, List, Tuple
 
-from kseg.data.lightning import DataModuleBase
 from kseg.model.loss import (
     DiceLoss,
     FocalLoss,
@@ -130,9 +128,7 @@ class ConfigHandler:
                 'WeightedCrossEntropyLoss': nn.CrossEntropyLoss(
                     weight=torch.Tensor(class_weights)
                 ),
-                'WeightedMSELoss': WeightedMSELoss(
-                    weight=torch.Tensor(class_weights)
-                ),
+                'WeightedMSELoss': WeightedMSELoss(weight=torch.Tensor(class_weights)),
             }
             replace_pattern.update(weighted_losses)
 
@@ -187,8 +183,7 @@ class ConfigHandler:
                 config.update(parsed_config['tuning'][model_name])
         else:
             raise ValueError(
-                f'No config for model \'{model_name}\' available. '
-                'Check config file.'
+                f'No config for model \'{model_name}\' available. ' 'Check config file.'
             )
 
         # Add information about shapes and domains. Write command line parameters

--- a/kseg/utils/convert.py
+++ b/kseg/utils/convert.py
@@ -15,15 +15,11 @@ def main():
 
 
 @main.command()
-@click.argument(
-    'src_path', default='/data/TBrecon1/miccai_challenge/train/untarred/'
-)
+@click.argument('src_path', default='/data/TBrecon1/miccai_challenge/train/untarred/')
 @click.argument('dest_path', default='/data/TBrecon3/kseg/')
 @click.option('--sanity-check', is_flag=True, default=False)
 @click.option('--resume', is_flag=True, default=False)
-def hdf2nii(
-    src_path: str, dest_path: str, sanity_check: bool, resume: bool
-) -> None:
+def hdf2nii(src_path: str, dest_path: str, sanity_check: bool, resume: bool) -> None:
     """Reads hdf files, splits each of them into image and label and save them.
 
     Args:
@@ -49,9 +45,7 @@ def hdf2nii(
 
         # Unzip data and store it to destination directory
         with gzip.open(file, 'rb') as infile:
-            with open(
-                os.path.join(dest_path, f'{file_name}.h5'), 'wb'
-            ) as outfile:
+            with open(os.path.join(dest_path, f'{file_name}.h5'), 'wb') as outfile:
                 shutil.copyfileobj(infile, outfile)
 
         # Convert hdf file to two separate nii files (kspace + seg)
@@ -69,13 +63,9 @@ def hdf2nii(
 
         # Sanity check - check if written things are the same as the read ones
         if sanity_check:
-            nii_kspace_file = nib.load(
-                os.path.join(dest_path, f'{file_name}.nii.gz')
-            )
+            nii_kspace_file = nib.load(os.path.join(dest_path, f'{file_name}.nii.gz'))
             nii_kspace = nii_kspace_file.get_fdata(dtype=np.complex64)
-            nii_seg_file = nib.load(
-                os.path.join(dest_path, f'{file_name}_seg.nii.gz')
-            )
+            nii_seg_file = nib.load(os.path.join(dest_path, f'{file_name}_seg.nii.gz'))
             nii_seg = nii_seg_file.get_fdata()
 
             if (not np.array_equal(nii_kspace, kspace)) or (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'einops',
     'opencv-python',
     'pandas',
-    #'perceiver-io',
+    'perceiver-io',
     'pyarrow',
     'pytorch_lightning == 2.0.5',
     'ray == 2.5.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'einops',
     'opencv-python',
     'pandas',
-    'perceiver-io',
+    #'perceiver-io',
     'pyarrow',
     'pytorch_lightning == 2.0.5',
     'ray == 2.5.1',
@@ -28,6 +28,9 @@ dependencies = [
     'torchmetrics == 0.9.3',
     'torchvision == 0.15.2'
 ]
+
+[project.optional-dependencies]
+docs = ["sphinx", "furo"]
 
 [tool.setuptools]
 py-modules = ["kseg"]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -3,24 +3,25 @@ import torchio
 
 from unittest import TestCase
 
+from kseg.data.custom_torchio import NDScalarImage
 from kseg.data.transforms import (
     KSpace,
     InverseKSpace,
     Complex2Vec,
+    Compress,
+    Decompress,
     Vec2Complex,
 )
 
 
 class TestKSpace(TestCase):
     def test_apply_transform(self):
-        transform = KSpace()
+        transform = KSpace(exclude_label=True)
 
         xs = torch.tensor([-1.0, -0.5, 0.5, 1])
         ys = torch.tensor([-1.0, -0.5, 0.5, 1])
         x, y = torch.meshgrid(xs, ys, indexing='xy')
-        image = torchio.ScalarImage(
-            tensor=torch.stack([x + y, x, y]).unsqueeze(0)
-        )
+        image = NDScalarImage(tensor=torch.stack([x + y, x, y]).unsqueeze(0))
 
         subject = torchio.Subject(one_image=image)
         transform.apply_transform(subject)
@@ -55,23 +56,23 @@ class TestKSpace(TestCase):
         )
 
     def test_is_invertible(self):
-        self.assertTrue(KSpace().is_invertible())
+        self.assertTrue(KSpace(exclude_label=True).is_invertible())
 
     def test_inverse(self):
-        self.assertEqual(type(KSpace().inverse()), InverseKSpace)
+        self.assertEqual(type(KSpace(exclude_label=True).inverse()), InverseKSpace)
 
 
 class TestInverseKSpace(TestCase):
     def test_apply_transform(self):
-        transform = KSpace()
-        inverse_transform = InverseKSpace()
+        transform = KSpace(exclude_label=True)
+        inverse_transform = InverseKSpace(exclude_label=True)
 
         xs = torch.tensor([-1.0, -0.5, 0.5, 1])
         ys = torch.tensor([-1.0, -0.5, 0.5, 1])
         x, y = torch.meshgrid(xs, ys, indexing='xy')
         data = torch.stack([x + y, x, y]).unsqueeze(0)
 
-        image = torchio.ScalarImage(tensor=data)
+        image = NDScalarImage(tensor=data)
         subject = torchio.Subject(one_image=image)
         transform.apply_transform(subject)
         inverse_transform.apply_transform(subject)
@@ -79,34 +80,41 @@ class TestInverseKSpace(TestCase):
         torch.testing.assert_close(subject.one_image.data, data)
 
     def test_is_invertible(self):
-        self.assertTrue(InverseKSpace().is_invertible())
+        self.assertTrue(InverseKSpace(exclude_label=True).is_invertible())
 
     def test_inverse(self):
-        self.assertEqual(type(InverseKSpace().inverse()), KSpace)
+        self.assertEqual(type(InverseKSpace(exclude_label=True).inverse()), KSpace)
 
 
 class TestComplex2Vec(TestCase):
     def test_apply_transform(self):
         transform = Complex2Vec()
-        image = torchio.ScalarImage(
-            tensor=torch.tensor(
+        data = torch.tensor(
+            [
                 [
                     [
-                        [[0.0 + 1.0j, 1.0 - 1.0j], [0.0 + 1.0j, 1.0 - 1.0j]],
-                        [[1, 1.0j], [2 + 1.0j, -1.0 + 2.0j]],
-                    ]
+                        [1.0 + 0.0j, 1.0 - 0.0j],
+                        [1.0 + 1.0j, 3.0 + 1.0j],
+                        [1.0 - 1.0j, 3.0 - 1.0j],
+                    ],
+                    [
+                        [2.0 - 0.0j, 1.0 + 0.0j],
+                        [3.0 + 1.0j, -1.0 - 2.0j],
+                        [2.0 - 1.0j, -1.0 + 2.0j],
+                    ],
                 ]
-            )
+            ]
         )
+        image = NDScalarImage(tensor=data)
         subject = torchio.Subject(one_image=image)
         transform.apply_transform(subject)
         torch.testing.assert_close(
-            image.data[:, :, :, 0],
-            torch.tensor([[[0.0, 1.0], [0.0, 1.0]], [[1, 0], [2, -1.0]]]),
+            image.data[:, 0, :, :, :],
+            torch.tensor([[[[1.0], [1.0], [1.0]], [[2.0], [3.0], [1.0]]]]),
         )
         torch.testing.assert_close(
-            image.data[:, :, :, 1],
-            torch.tensor([[[1.0, -1.0], [1.0, -1.0]], [[0, 1], [1, 2.0]]]),
+            image.data[:, 1, :, :, :],
+            torch.tensor([[[[1.0], [3.0], [1.0]], [[1.0], [-1.0], [-2.0]]]]),
         )
 
     def test_is_invertible(self):
@@ -123,19 +131,110 @@ class TestVec2Complex(TestCase):
         data = torch.tensor(
             [
                 [
-                    [[0.0 + 1.0j, 1.0 - 1.0j], [0.0 + 1.0j, 1.0 - 1.0j]],
-                    [[1, 1.0j], [2 + 1.0j, -1.0 + 2.0j]],
+                    [
+                        [1.0 + 0.0j, 1.0 - 0.0j],
+                        [1.0 + 1.0j, 3.0 + 1.0j],
+                        [1.0 - 1.0j, 3.0 - 1.0j],
+                    ],
+                    [
+                        [2.0 - 0.0j, 1.0 + 0.0j],
+                        [3.0 + 1.0j, -1.0 - 2.0j],
+                        [2.0 - 1.0j, -1.0 + 2.0j],
+                    ],
                 ]
             ]
         )
-        image = torchio.ScalarImage(tensor=data)
+        image = NDScalarImage(tensor=data)
         subject = torchio.Subject(one_image=image)
         transform.apply_transform(subject)
         inverse_transform.apply_transform(subject)
-        torch.testing.assert_close(image.data, data)
+        # Why does the inverse transform unsqueeze the tensor?
+        torch.testing.assert_close(image.data, torch.unsqueeze(data, dim=1))
 
     def test_is_invertible(self):
         self.assertTrue(Vec2Complex().is_invertible())
 
     def test_inverse(self):
         self.assertEqual(type(Vec2Complex().inverse()), Complex2Vec)
+
+
+class TestCompress(TestCase):
+    def test_apply_transform(self):
+        transform = Compress()
+        data = torch.tensor(
+            [
+                [
+                    [
+                        [[1.0, 0.0, 1.0], [1.0, 0.0, 3.0], [1.0, 2.0, 3.0]],
+                        [[2.0, 3.0, 1.0], [3.0, -1.2, -1.0], [2.0, 2.3, -1.0]],
+                    ],
+                    [
+                        [[0.0, 0.5, 0.0], [-1.0, 2.0, 1.0], [1.0, 3.0, 1.0]],
+                        [[0.0, 1.0, 0.0], [1.0, -1.0, -2.0], [-1.0, 2.0, 2.0]],
+                    ],
+                ]
+            ]
+        )
+        image = NDScalarImage(tensor=data)
+        subject = torchio.Subject(one_image=image)
+        transform.apply_transform(subject)
+
+        torch.testing.assert_close(
+            image.data[:, 0, :, :, :],
+            torch.tensor(
+                [
+                    [
+                        [[1.0, 0.0], [1.0, 0.0], [-1.0, 2.0]],
+                        [[2.0, 3.0], [3.0, -1.2], [1.0, 2.3]],
+                    ]
+                ]
+            ),
+        )
+        torch.testing.assert_close(
+            image.data[:, 1, :, :, :],
+            torch.tensor(
+                [
+                    [
+                        [[1.0, 0.5], [3.0, 2.0], [1.0, 3.0]],
+                        [[1.0, 1.0], [-1.0, -1.0], [-2.0, 2.0]],
+                    ]
+                ]
+            ),
+        )
+
+    def test_is_invertible(self):
+        self.assertTrue(Compress().is_invertible())
+
+    def test_inverse(self):
+        self.assertEqual(type(Compress().inverse()), Decompress)
+
+
+class TestDecompress(TestCase):
+    def test_apply_transform(self):
+        transform = Compress()
+        inverse_transform = Decompress()
+        data = torch.tensor(
+            [
+                [
+                    [
+                        [[1.0, 0.0, 1.0], [1.0, 0.0, 3.0], [1.0, 2.0, 3.0]],
+                        [[2.0, 3.0, 1.0], [3.0, -1.2, -1.0], [3.0, 2.3, -1.0]],
+                    ],
+                    [
+                        [[0.0, 0.5, 0.0], [-1.0, 2.0, -1.0], [1.0, 3.0, 1.0]],
+                        [[0.0, 1.0, 0.0], [1.0, -1.0, -2.0], [-1.0, 2.0, 2.0]],
+                    ],
+                ]
+            ]
+        )
+        image = NDScalarImage(tensor=data)
+        subject = torchio.Subject(one_image=image)
+        transform.apply_transform(subject)
+        inverse_transform.apply_transform(subject)
+        torch.testing.assert_close(image.data, data)
+
+    def test_is_invertible(self):
+        self.assertTrue(Decompress().is_invertible())
+
+    def test_inverse(self):
+        self.assertEqual(type(Decompress().inverse()), Compress)


### PR DESCRIPTION
## Description
This PR adds `Compress` and `Decompress` transforms which results in the KSpace network having the same input dimension as the pixel space network.

## Motivation and Context
If the original image has size (1, 1, 64, 64, 64), after applying `KSpace`, we get a (1, 1, 64, 64, 33) complex tensor, and
after applying Complex2Vec, we get a (1, 2, 64, 64, 33) real tensor. The dimension of this tensor is larger than the original image. However, there is some redundancy here. The Compress transform applies a lossless compression using conjugate symmetries present in the first and last columns of the tensor to reduce its dimensions to (1, 2, 64, 64, 32) which is equivalent to the original image.

## Test Plan
Added two unit tests for `Compress` and `Decompress` transforms. Have to run the pipeline manually to test integration. 

## Reviewers
@egosche 
