### PR TITLE
Upgrade einops to use pack module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     'click == 8.1.6',
-    'einops',
+    'einops == 0.6.1',
     'opencv-python',
     'pandas',
-    'perceiver-io',
+    'perceiver-io @ git+https://github.com/egosche/perceiver-io@main',
     'pyarrow',
     'pytorch_lightning == 2.0.5',
     'ray == 2.5.1',


### PR DESCRIPTION
## Description
Specifies a suited einops version and uses forked perceiver-io which relaxes einops version constrains.

## Related Issues
kseg package was not installable because of dependency conflicts between perceiver-io and kseg.

## Motivation and Context
The changes from #3 introduce the usage of einops.pack. However, this submodule is available starting at einops version 0.6.0. The original perceiver-io package requires einops = "^0.4". To solve this conflict, a fork of perceiver-io with relaxed version constrains is used.

## Test Plan
None.

## Reviewers
@reghbali 
