### PR TITLE
Exclude labels in compress step for kspixel pipeline

### DIFF
--- a/kseg/data/custom_torchio.py
+++ b/kseg/data/custom_torchio.py
@@ -1,15 +1,15 @@
 import copy
+import warnings
+from pathlib import Path
+from typing import List, Optional
+
 import nibabel as nib
 import numpy as np
 import SimpleITK as sitk
 import torch
 import torchio
-import warnings
-
-from pathlib import Path
 from torchio.data.image import Image
 from torchio.data.subject import Subject
-from typing import Optional
 
 
 class NDScalarImage(torchio.ScalarImage):
@@ -231,9 +231,18 @@ class NDDataParser(torchio.transforms.data_parser.DataParser):
 class NDTransform(torchio.Transform):
     """Extends torchio Transform class to support n-dimensional tensors."""
 
-    def __init__(self) -> None:
-        """Initialization of the NDTransform class."""
+    def __init__(self, exclude_label: bool = False) -> None:
+        """Initialization of the NDTransform class.
+
+        Args:
+            exclude_label: Whether to exlcude the label for the transformation.
+                Defaults to False.
+
+        Returns:
+            None.
+        """
         super().__init__()
+        self.exclude_label = exclude_label
 
     def __call__(self, data):
         """Overrides the torchio.Transform __call__ method."""
@@ -270,3 +279,11 @@ class NDTransform(torchio.Transform):
             output = transformed
 
         return output
+
+    def get_images(self, subject: torchio.Subject) -> List[torchio.Image]:
+        images = subject.get_images(
+            intensity_only=self.exclude_label,
+            include=self.include,
+            exclude=self.exclude,
+        )
+        return images

--- a/kseg/data/lightning.py
+++ b/kseg/data/lightning.py
@@ -1,16 +1,15 @@
 import glob
 import os
 import re
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
 
 import pytorch_lightning as pl
 import torch
 import torchio
 
-from pathlib import Path
-from typing import List, Optional, Tuple, Union
-
-from kseg.data.custom_torchio import NDScalarImage, NDLabelMap
-from kseg.data.transforms import KSpace, Complex2Vec, Unsqueeze, Compress
+from kseg.data.custom_torchio import NDLabelMap, NDScalarImage
+from kseg.data.transforms import Complex2Vec, Compress, KSpace, Unsqueeze
 
 
 class DataModuleBase(pl.LightningDataModule):
@@ -166,11 +165,9 @@ class DataModuleBase(pl.LightningDataModule):
         if self.input_domain == 'kspace':
             domain_transform = torchio.Compose(
                 [
-                    KSpace(
-                        exclude_label=(self.label_domain == 'pixel'),
-                    ),
+                    KSpace(exclude_label=(self.label_domain == 'pixel')),
                     Complex2Vec(),
-                    Compress(),
+                    Compress(exclude_label=(self.label_domain == 'pixel')),
                 ]
             )
             self.train_transform = torchio.Compose(


### PR DESCRIPTION
## Description
The compression transformation is applied on the input and label for each subject if the input domain is set to 'k-space'. However, if the label domain is set to 'pixel', the labels are not Fourier-transformed and therefore no compression is needed. To solve this problem, the compression transformation is excluding the labels of each subject if the label domain is set to 'pixel'.

## Related Issues
 Compression transformation was raising an IndexError if label domain was set to 'pixel' because in this case, the complex value axis in the label tensor is of length 1 and not 2.

## Motivation and Context
Solves an issue which broke the 'kspixel' pipeline.

## Test Plan
No additional test added.

## Reviewers
@reghbali 
